### PR TITLE
Just use POST for MFA form submissions

### DIFF
--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -78,6 +78,7 @@ services:
     env_file:
       - ./common.env
     environment:
+      - MFA_SETUP_URL=https://www.google.com
       - THEME_USE=default:default
     working_dir: /data
     command: /data/run-tests.sh

--- a/features/context/MfaContext.php
+++ b/features/context/MfaContext.php
@@ -71,7 +71,6 @@ class MfaContext implements Context
     protected function getContinueButton($page)
     {
         $continueButton = $page->find('css', '[name=continue]');
-        Assert::assertNotNull($continueButton, 'Failed to find the continue button');
         return $continueButton;
     }
     
@@ -390,6 +389,7 @@ class MfaContext implements Context
     {
         $page = $this->session->getPage();
         $continueButton = $this->getContinueButton($page);
+        Assert::assertNotNull($continueButton, 'Failed to find the continue button');
         $continueButton->click();
         $this->submitSecondarySspFormIfPresent($page);
     }
@@ -414,5 +414,15 @@ class MfaContext implements Context
         Assert::assertNotEmpty($mfaSetupUrl);
         $currentUrl = $this->session->getCurrentUrl();
         Assert::assertStringStartsWith($mfaSetupUrl, $currentUrl);
+    }
+
+    /**
+     * @Then there should NOT be a way to continue to my intended destination
+     */
+    public function thereShouldNotBeAWayToContinueToMyIntendedDestination()
+    {
+        $page = $this->session->getPage();
+        $continueButton = $this->getContinueButton($page);
+        Assert::assertNull($continueButton, 'Should not have found a continue button');
     }
 }

--- a/features/context/MfaContext.php
+++ b/features/context/MfaContext.php
@@ -8,6 +8,7 @@ use Behat\Mink\Element\DocumentElement;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;
 use PHPUnit\Framework\Assert;
+use Sil\PhpEnv\Env;
 use Sil\SspMfa\Behat\fakes\FakeIdBrokerClient;
 
 /**
@@ -62,6 +63,19 @@ class MfaContext implements Context
     }
     
     /**
+     * Get the "continue" button.
+     *
+     * @param DocumentElement $page The page.
+     * @return NodeElement
+     */
+    protected function getContinueButton($page)
+    {
+        $continueButton = $page->find('css', '[name=continue]');
+        Assert::assertNotNull($continueButton, 'Failed to find the continue button');
+        return $continueButton;
+    }
+    
+    /**
      * Get the login button from the given page.
      *
      * @param DocumentElement $page The page.
@@ -80,6 +94,19 @@ class MfaContext implements Context
         }
         Assert::assertNotNull($loginButton, 'Failed to find the login button');
         return $loginButton;
+    }
+    
+    /**
+     * Get the button for going to set up MFA.
+     *
+     * @param DocumentElement $page The page.
+     * @return NodeElement
+     */
+    protected function getSetUpMfaButton($page)
+    {
+        $setUpMfaButton = $page->find('css', '[name=setUpMfa]');
+        Assert::assertNotNull($setUpMfaButton, 'Failed to find the set-up-MFA button');
+        return $setUpMfaButton;
     }
     
     /**
@@ -140,8 +167,8 @@ class MfaContext implements Context
      */
     protected function submitMfaForm($page)
     {
-        $loginButton = $this->getSubmitMfaButton($page);
-        $loginButton->click();
+        $submitMfaButton = $this->getSubmitMfaButton($page);
+        $submitMfaButton->click();
         $this->submitSecondarySspFormIfPresent($page);
     }
     
@@ -320,7 +347,72 @@ class MfaContext implements Context
      */
     public function iProvideCredentialsThatHaveARateLimitedMfa()
     {
+        // See `development/idp-local/config/authsources.php` for options.
         $this->username = 'has_rate_limited_mfa';
         $this->password = 'a';
+    }
+
+    /**
+     * @Given I provide credentials that will be nagged to set up MFA
+     */
+    public function iProvideCredentialsThatWillBeNaggedToSetUpMfa()
+    {
+        // See `development/idp-local/config/authsources.php` for options.
+        $this->username = 'nag_for_mfa';
+        $this->password = 'a';
+    }
+
+    /**
+     * @Then I should see a message encouraging me to set up MFA
+     */
+    public function iShouldSeeAMessageEncouragingMeToSetUpMfa()
+    {
+        $page = $this->session->getPage();
+        Assert::assertContains(
+            'increase the security of your account by enabling 2-',
+            $page->getHtml()
+        );
+    }
+
+    /**
+     * @Then there should be a way to continue to my intended destination
+     */
+    public function thereShouldBeAWayToContinueToMyIntendedDestination()
+    {
+        $page = $this->session->getPage();
+        $this->assertFormContains('name="continue"', $page);
+    }
+
+    /**
+     * @When I click the remind-me-later button
+     */
+    public function iClickTheRemindMeLaterButton()
+    {
+        $page = $this->session->getPage();
+        $continueButton = $this->getContinueButton($page);
+        $continueButton->click();
+        $this->submitSecondarySspFormIfPresent($page);
+    }
+
+    /**
+     * @When I click the set-up-MFA button
+     */
+    public function iClickTheSetUpMfaButton()
+    {
+        $page = $this->session->getPage();
+        $setUpMfaButton = $this->getSetUpMfaButton($page);
+        $setUpMfaButton->click();
+        $this->submitSecondarySspFormIfPresent($page);
+    }
+
+    /**
+     * @Then I should end up at the mfa-setup URL
+     */
+    public function iShouldEndUpAtTheMfaSetupUrl()
+    {
+        $mfaSetupUrl = Env::get('MFA_SETUP_URL');
+        Assert::assertNotEmpty($mfaSetupUrl);
+        $currentUrl = $this->session->getCurrentUrl();
+        Assert::assertStringStartsWith($mfaSetupUrl, $currentUrl);
     }
 }

--- a/features/mfa.feature
+++ b/features/mfa.feature
@@ -5,6 +5,25 @@ Feature: Prompt for MFA credentials
     When I login
     Then I should end up at my intended destination
 
+  Scenario: Nag to set up MFA
+    Given I provide credentials that will be nagged to set up MFA
+    When I login
+    Then I should see a message encouraging me to set up MFA
+      And there should be a way to go set up MFA now
+      And there should be a way to continue to my intended destination
+
+  Scenario: Obeying the nag to set up MFA
+    Given I provide credentials that will be nagged to set up MFA
+      And I login
+    When I click the set-up-MFA button
+    Then I should end up at the mfa-setup URL
+
+  Scenario: Ignoring the nag to set up MFA
+    Given I provide credentials that will be nagged to set up MFA
+      And I login
+    When I click the remind-me-later button
+    Then I should end up at my intended destination
+
   Scenario: Needs MFA, but no MFA options are available
     Given I provide credentials that need MFA but have no MFA options available
     When I login

--- a/features/mfa.feature
+++ b/features/mfa.feature
@@ -29,6 +29,13 @@ Feature: Prompt for MFA credentials
     When I login
     Then I should see a message that I have to set up MFA
       And there should be a way to go set up MFA now
+      And there should NOT be a way to continue to my intended destination
+
+  Scenario: Following the requirement to go set up MFA
+    Given I provide credentials that need MFA but have no MFA options available
+      And I login
+    When I click the set-up-MFA button
+    Then I should end up at the mfa-setup URL
 
   Scenario: Needs MFA, has backup code option available
     Given I provide credentials that need MFA and have backup codes available

--- a/lib/Auth/Process/Mfa.php
+++ b/lib/Auth/Process/Mfa.php
@@ -490,8 +490,13 @@ class sspmod_mfa_Auth_Process_Mfa extends SimpleSAML_Auth_ProcessingFilter
         
         $id = SimpleSAML_Auth_State::saveState($state, self::STAGE_SENT_TO_MFA_PROMPT);
         $url = SimpleSAML_Module::getModuleURL('mfa/prompt-for-mfa.php');
+
+        $mfaOption = self::getMfaOptionToUse($mfaOptions);
         
-        SimpleSAML_Utilities::redirect($url, array('StateId' => $id));
+        SimpleSAML_Utilities::redirect($url, [
+            'mfaId' => $mfaOption['id'],
+            'StateId' => $id,
+        ]);
     }
 
     /**

--- a/templates/must-set-up-mfa.php
+++ b/templates/must-set-up-mfa.php
@@ -1,7 +1,5 @@
 <?php
-
-$this->data['header'] = 'Set up 2-step verification';
-
+$this->data['header'] = 'Set up 2-Step Verification';
 $this->includeAtTemplateBase('includes/header.php');
 
 ?>

--- a/templates/must-set-up-mfa.php
+++ b/templates/must-set-up-mfa.php
@@ -1,25 +1,15 @@
 <?php
 $this->data['header'] = 'Set up 2-Step Verification';
 $this->includeAtTemplateBase('includes/header.php');
-
 ?>
 <p>
   Your account requires additional security. 
   You must set up 2-step verification at this time.
 </p>
-<form action="<?= htmlentities($this->data['formTarget']); ?>">
-  
-    <?php foreach ($this->data['formData'] as $name => $value): ?>
-        <input type="hidden"
-               name="<?= htmlentities($name); ?>"
-               value="<?= htmlentities($value); ?>" />
-    <?php endforeach; ?>
-    
-    <button type="submit" id="setUpMfa" name="setUpMfa"
-            style="padding: 4px 8px;">
+<form method="post">
+    <button name="setUpMfa" style="padding: 4px 8px;">
         Set up 2-step verification
     </button>
 </form>
 <?php
-
 $this->includeAtTemplateBase('includes/footer.php');

--- a/templates/nag-for-mfa.php
+++ b/templates/nag-for-mfa.php
@@ -1,7 +1,5 @@
 <?php
-
-$this->data['header'] = 'Set up 2-step verification';
-
+$this->data['header'] = 'Set up 2-Step Verification';
 $this->includeAtTemplateBase('includes/header.php');
 
 ?>

--- a/templates/nag-for-mfa.php
+++ b/templates/nag-for-mfa.php
@@ -1,32 +1,21 @@
 <?php
 $this->data['header'] = 'Set up 2-Step Verification';
 $this->includeAtTemplateBase('includes/header.php');
-
 ?>
-    <p>
-        Did you know you could greatly increase the security of your account by enabling 2-Step Verification?
-    </p>
-    <p>
-        We highly encourage you to do this for your own safety
-    </p>
-    <form action="<?= htmlentities($this->data['formTarget']); ?>">
-
-        <?php foreach ($this->data['formData'] as $name => $value): ?>
-            <input type="hidden"
-                   name="<?= htmlentities($name); ?>"
-                   value="<?= htmlentities($value); ?>" />
-        <?php endforeach; ?>
-
-        <button type="submit" id="setUpMfa" name="setUpMfa"
-                style="padding: 4px 8px;">
-            Set up 2-step verification
-        </button>
-
-        <button type="submit" id="continue" name="continue"
-                style="padding: 4px 8px;">
-            Remind me later
-        </button>
-    </form>
+<p>
+    Did you know you could greatly increase the security of your account by enabling 2-Step Verification?
+</p>
+<p>
+    We highly encourage you to do this for your own safety
+</p>
+<form method="post">
+    <button name="setUpMfa" style="padding: 4px 8px;">
+        Set up 2-step verification
+    </button>
+    
+    <button name="continue" style="padding: 4px 8px;">
+        Remind me later
+    </button>
+</form>
 <?php
-
 $this->includeAtTemplateBase('includes/footer.php');

--- a/templates/prompt-for-mfa-backupcode.php
+++ b/templates/prompt-for-mfa-backupcode.php
@@ -12,14 +12,7 @@ if ( ! empty($this->data['errorMessage'])) {
 }
 
 ?>
-<form action="<?= htmlentities($this->data['formTarget']); ?>" method="POST">
-  
-    <?php foreach ($this->data['formData'] as $name => $value): ?>
-        <input type="hidden"
-               name="<?= htmlentities($name); ?>"
-               value="<?= htmlentities($value); ?>" />
-    <?php endforeach; ?>
-    
+<form method="post">
     <p><b>Backup code</b></p>
     <p>
       Each code can only be used once, so the code you enter this time will be
@@ -35,27 +28,27 @@ if ( ! empty($this->data['errorMessage'])) {
                 style="padding: 4px 8px;">Submit</button>
     </p>
     <?php
-        if (count($this->data['mfaOptions']) > 1) {
-            ?>
-            <p>
-                Don't have your backup codes handy? You may also use:
-                <ul>
+    if (count($this->data['mfaOptions']) > 1) {
+        ?>
+        <p>
+            Don't have your backup codes handy? You may also use:
+        <ul>
             <?php
             foreach ($this->data['mfaOptions'] as $mfaOpt) {
                 if ($mfaOpt['type'] != 'backupcode'){
                     ?>
-                    <li><a href="<?=htmlentities($this->data['formTarget'])?>?StateId=<?=$this->data['stateId']?>&mfaId=<?=$mfaOpt['id']?>"><?=$mfaOpt['type']?></a></li>
+                    <li><a href="prompt-for-mfa.php?StateId=<?= htmlentities($this->data['stateId']) ?>&mfaId=<?= htmlentities($mfaOpt['id']) ?>"><?=
+                       htmlentities($mfaOpt['type'])
+                    ?></a></li>
                     <?php
                 }
             }
             ?>
-                </ul>
-            </p>
-            <?php
-        }
+        </ul>
+        </p>
+        <?php
+    }
     ?>
-
 </form>
 <?php
-
 $this->includeAtTemplateBase('includes/footer.php');

--- a/templates/prompt-for-mfa-backupcode.php
+++ b/templates/prompt-for-mfa-backupcode.php
@@ -1,6 +1,5 @@
 <?php
-
-$this->data['header'] = '2-step verification';
+$this->data['header'] = '2-Step Verification';
 $this->includeAtTemplateBase('includes/header.php');
 
 if ( ! empty($this->data['errorMessage'])) {

--- a/templates/prompt-for-mfa-totp.php
+++ b/templates/prompt-for-mfa-totp.php
@@ -12,14 +12,7 @@ if ( ! empty($this->data['errorMessage'])) {
 }
 
 ?>
-<form action="<?= htmlentities($this->data['formTarget']); ?>" method="POST">
-  
-    <?php foreach ($this->data['formData'] as $name => $value): ?>
-        <input type="hidden"
-               name="<?= htmlentities($name); ?>"
-               value="<?= htmlentities($value); ?>" />
-    <?php endforeach; ?>
-    
+<form method="post">
     <p><b>Verification app</b></p>
     <p>
         Enter 6-digit code: <input type="text" autofocus id="mfaSubmission" name="mfaSubmission" />
@@ -40,7 +33,9 @@ if ( ! empty($this->data['errorMessage'])) {
             foreach ($this->data['mfaOptions'] as $mfaOpt) {
                 if ($mfaOpt['type'] != 'totp'){
                     ?>
-                    <li><a href="<?=htmlentities($this->data['formTarget'])?>?StateId=<?=$this->data['stateId']?>&mfaId=<?=$mfaOpt['id']?>"><?=$mfaOpt['type']?></a></li>
+                    <li><a href="prompt-for-mfa.php?StateId=<?= htmlentities($this->data['stateId']) ?>&mfaId=<?= htmlentities($mfaOpt['id']) ?>"><?=
+                       htmlentities($mfaOpt['type'])
+                    ?></a></li>
                     <?php
                 }
             }
@@ -52,5 +47,4 @@ if ( ! empty($this->data['errorMessage'])) {
     ?>
 </form>
 <?php
-
 $this->includeAtTemplateBase('includes/footer.php');

--- a/templates/prompt-for-mfa-totp.php
+++ b/templates/prompt-for-mfa-totp.php
@@ -1,6 +1,5 @@
 <?php
-
-$this->data['header'] = '2-step verification';
+$this->data['header'] = '2-Step Verification';
 $this->includeAtTemplateBase('includes/header.php');
 
 if ( ! empty($this->data['errorMessage'])) {

--- a/templates/prompt-for-mfa-u2f.php
+++ b/templates/prompt-for-mfa-u2f.php
@@ -1,6 +1,5 @@
 <?php
-
-$this->data['header'] = '2-step verification';
+$this->data['header'] = '2-Step Verification';
 $this->includeAtTemplateBase('includes/header.php');
 
 ?>

--- a/templates/prompt-for-mfa-u2f.php
+++ b/templates/prompt-for-mfa-u2f.php
@@ -1,7 +1,6 @@
 <?php
 $this->data['header'] = '2-Step Verification';
 $this->includeAtTemplateBase('includes/header.php');
-
 ?>
 <script src="<?=SimpleSAML_Module::getModuleURL('mfa/u2f-api.js');?>"></script>
 <script type="application/javascript">
@@ -25,14 +24,7 @@ $this->includeAtTemplateBase('includes/header.php');
       });
     }
 </script>
-<form action="<?= htmlentities($this->data['formTarget']); ?>" method="POST" id="mfaForm">
-  
-    <?php foreach ($this->data['formData'] as $name => $value): ?>
-        <input type="hidden"
-               name="<?= htmlentities($name); ?>"
-               value="<?= htmlentities($value); ?>" />
-    <?php endforeach; ?>
-    
+<form method="post">
     <p id="mfaInstructions">Please insert your security key and press its button.</p>
     <p>
         <input type="checkbox" name="rememberMe" id="rememberMe" value="true" checked="checked"/>
@@ -53,7 +45,9 @@ $this->includeAtTemplateBase('includes/header.php');
             foreach ($this->data['mfaOptions'] as $mfaOpt) {
                 if ($mfaOpt['type'] != 'u2f'){
                     ?>
-                    <li><a href="<?=htmlentities($this->data['formTarget'])?>?StateId=<?=$this->data['stateId']?>&mfaId=<?=$mfaOpt['id']?>"><?=$mfaOpt['type']?></a></li>
+                    <li><a href="prompt-for-mfa.php?StateId=<?= htmlentities($this->data['stateId']) ?>&mfaId=<?= htmlentities($mfaOpt['id']) ?>"><?=
+                       htmlentities($mfaOpt['type'])
+                    ?></a></li>
                     <?php
                 }
             }

--- a/www/must-set-up-mfa.php
+++ b/www/must-set-up-mfa.php
@@ -10,7 +10,7 @@ if (empty($stateId)) {
 $state = SimpleSAML_Auth_State::loadState($stateId, Mfa::STAGE_SENT_TO_MFA_NEEDED_MESSAGE);
 
 // If the user has pressed the set-up-MFA button...
-if (filter_has_var(INPUT_GET, 'setUpMfa')) {
+if (filter_has_var(INPUT_POST, 'setUpMfa')) {
     $mfaSetupUrl = $state['mfaSetupUrl'];
     
     // Tell the MFA-setup URL where the user is ultimately trying to go (if known).
@@ -30,8 +30,6 @@ if (filter_has_var(INPUT_GET, 'setUpMfa')) {
 $globalConfig = SimpleSAML_Configuration::getInstance();
 
 $t = new SimpleSAML_XHTML_Template($globalConfig, 'mfa:must-set-up-mfa.php');
-$t->data['formTarget'] = SimpleSAML_Module::getModuleURL('mfa/must-set-up-mfa.php');
-$t->data['formData'] = ['StateId' => $stateId];
 $t->show();
 
 SimpleSAML_Logger::info(sprintf(

--- a/www/nag-for-mfa.php
+++ b/www/nag-for-mfa.php
@@ -10,7 +10,7 @@ if (empty($stateId)) {
 $state = SimpleSAML_Auth_State::loadState($stateId, Mfa::STAGE_SENT_TO_MFA_NAG);
 
 // If the user has pressed the set-up-MFA button...
-if (filter_has_var(INPUT_GET, 'setUpMfa')) {
+if (filter_has_var(INPUT_POST, 'setUpMfa')) {
     $mfaSetupUrl = $state['mfaSetupUrl'];
 
     // Tell the MFA-setup URL where the user is ultimately trying to go (if known).
@@ -25,7 +25,7 @@ if (filter_has_var(INPUT_GET, 'setUpMfa')) {
 
     SimpleSAML_Utilities::redirect($mfaSetupUrl);
     return;
-} elseif (filter_has_var(INPUT_GET, 'continue')) {
+} elseif (filter_has_var(INPUT_POST, 'continue')) {
     // The user has pressed the continue button.
     //unset($state['Attributes']['mfa']);
     SimpleSAML_Auth_ProcessingChain::resumeProcessing($state);
@@ -34,8 +34,6 @@ if (filter_has_var(INPUT_GET, 'setUpMfa')) {
 $globalConfig = SimpleSAML_Configuration::getInstance();
 
 $t = new SimpleSAML_XHTML_Template($globalConfig, 'mfa:nag-for-mfa.php');
-$t->data['formTarget'] = SimpleSAML_Module::getModuleURL('mfa/nag-for-mfa.php');
-$t->data['formData'] = ['StateId' => $stateId];
 $t->show();
 
 SimpleSAML_Logger::info(sprintf(

--- a/www/prompt-for-mfa.php
+++ b/www/prompt-for-mfa.php
@@ -11,8 +11,7 @@ use sspmod_mfa_Auth_Process_Mfa as Mfa;
 use Sil\PhpEnv\Env;
 use Sil\Psr3Adapters\Psr3SamlLogger;
 
-$stateId = filter_input(INPUT_POST, 'StateId') ?? null;
-$stateId = $stateId ?? filter_input(INPUT_GET, 'StateId');
+$stateId = filter_input(INPUT_GET, 'StateId');
 if (empty($stateId)) {
     throw new SimpleSAML_Error_BadRequest('Missing required StateId query parameter.');
 }

--- a/www/prompt-for-mfa.php
+++ b/www/prompt-for-mfa.php
@@ -90,8 +90,6 @@ $globalConfig = SimpleSAML_Configuration::getInstance();
 $mfaTemplateToUse = Mfa::getTemplateFor($mfaOption['type']);
 
 $t = new SimpleSAML_XHTML_Template($globalConfig, $mfaTemplateToUse);
-$t->data['formTarget'] = SimpleSAML_Module::getModuleURL('mfa/prompt-for-mfa.php');
-$t->data['formData'] = ['StateId' => $stateId, 'mfaId' => $mfaId];
 $t->data['errorMessage'] = $errorMessage ?? null;
 $t->data['mfaOption'] = $mfaOption;
 $t->data['mfaOptions'] = $mfaOptions;


### PR DESCRIPTION
The default prompt-for-mfa templates in this MFA module were already using `POST`, but this gets the nag-for-mfa and must-set-up-mfa forms to do so, as well.

This also simplifies the forms by removing the (unnecessary) `formTarget` and `formData`. The only piece that we had needed `formData` for was, sometimes, the `mfaId`, so we switch it to always be in the URL (instead of sometimes in the URL, and sometimes not).

This also adds some automated tests that prove that the form submissions (at least for nag-for-mfa and must-set-up-mfa) actually work, proving that the GET/POST change didn't break things.

@wcjr Once this is done you should be able to make similar simplifications in the material theme module, as we discussed.