### PR TITLE
Another SimpleSAMLphp 1.15.x fix

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -605,12 +605,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "a5ff7ff05264c8796ffb1b7b6fdde43a9c6b0776"
+                "reference": "3df94834c80037130b533703df4672785b6ea112"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/a5ff7ff05264c8796ffb1b7b6fdde43a9c6b0776",
-                "reference": "a5ff7ff05264c8796ffb1b7b6fdde43a9c6b0776",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/3df94834c80037130b533703df4672785b6ea112",
+                "reference": "3df94834c80037130b533703df4672785b6ea112",
                 "shasum": ""
             },
             "conflict": {
@@ -694,7 +694,7 @@
                 "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4",
                 "symfony/yaml": ">=2,<2.0.22|>=2.1,<2.1.7",
                 "thelia/backoffice-default-template": ">=2.1,<2.1.2",
-                "thelia/thelia": ">=2.1,<2.1.2|>=2.1.0-beta1,<2.1.3",
+                "thelia/thelia": ">=2.1.0-beta1,<2.1.3|>=2.1,<2.1.2",
                 "twig/twig": "<1.20",
                 "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.22|>=8,<8.7.5",
                 "typo3/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.10|>=3.1,<3.1.7|>=3.2,<3.2.7|>=3.3,<3.3.5",
@@ -743,7 +743,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2018-01-31T19:36:12+00:00"
+            "time": "2018-02-04T22:09:50+00:00"
         },
         {
             "name": "robrichards/xmlseclibs",

--- a/features/context/MfaContext.php
+++ b/features/context/MfaContext.php
@@ -196,12 +196,9 @@ class MfaContext implements Context
      */
     protected function submitSecondarySspFormIfPresent($page)
     {
-        $body = $page->find('css', 'body');
-        if ($body instanceof NodeElement) {
-            $onload = $body->getAttribute('onload');
-            if ($onload === "document.getElementsByTagName('input')[0].click();") {
-                $body->pressButton('Submit');
-            }
+        $postLoginSubmitButton = $page->findButton('postLoginSubmitButton');
+        if ($postLoginSubmitButton instanceof NodeElement) {
+            $postLoginSubmitButton->click();
         }
     }
     

--- a/features/context/MfaContext.php
+++ b/features/context/MfaContext.php
@@ -196,9 +196,20 @@ class MfaContext implements Context
      */
     protected function submitSecondarySspFormIfPresent($page)
     {
+        // SimpleSAMLphp 1.15 markup for secondary page:
         $postLoginSubmitButton = $page->findButton('postLoginSubmitButton');
         if ($postLoginSubmitButton instanceof NodeElement) {
             $postLoginSubmitButton->click();
+        } else {
+            
+            // SimpleSAMLphp 1.14 markup for secondary page:
+            $body = $page->find('css', 'body');
+            if ($body instanceof NodeElement) {
+                $onload = $body->getAttribute('onload');
+                if ($onload === "document.getElementsByTagName('input')[0].click();") {
+                    $body->pressButton('Submit');
+                }
+            }
         }
     }
     


### PR DESCRIPTION
This is a relatively minor fix that just affects tests. They changed a little of the markup on the page shown when a second page/form must be shown for some reason, but the user's browser doesn't have JavaScript enabled (preventing them from having it automatically submit).

**EDIT:** Until ssp-base:latest is running simplesamlphp 1.15, this code needs to support both formats of the secondary page (1.14 and 1.15).