### PR TITLE
Add mfa recovery page

### DIFF
--- a/development/idp-local/config/authsources.php
+++ b/development/idp-local/config/authsources.php
@@ -638,5 +638,39 @@ $config = [
             ],
             'manager_email' => ['manager@example.com'],
         ],
+        'has_mgr_code:a' => [
+            'eduPersonPrincipalName' => ['has_mgr_code@mfaidp'],
+            'eduPersonTargetID' => ['00000015-0015-0015-0015-000000000015'],
+            'sn' => ['Manager Code'],
+            'givenName' => ['Has'],
+            'mail' => ['has_mgr_code@example.com'],
+            'employeeNumber' => ['00015'],
+            'cn' => ['HAS_MGR_CODE'],
+            'mfa' => [
+                'prompt' => 'yes',
+                'add' => 'no',
+                'review' => 'no',
+                'options' => [
+                    [
+                        'id' => '151',
+                        'type' => 'backupcode',
+                        'data' => [
+                            'count' => 10,
+                        ],
+                    ],
+                    [
+                        'id' => '151',
+                        'type' => 'manager',
+                        'data' => '',
+                    ],
+                ],
+            ],
+            'method' => [
+                'add' => 'no',
+                'review' => 'no',
+                'options' => [],
+            ],
+            'manager_email' => ['manager@example.com'],
+        ],
     ],
 ];

--- a/features/context/MfaContext.php
+++ b/features/context/MfaContext.php
@@ -681,7 +681,7 @@ class MfaContext implements Context
     public function iShouldSeeALinkToSendACodeToTheUsersManager()
     {
         $page = $this->session->getPage();
-        Assert::assertContains('Send a code</a> to your manager', $page->getContent());
+        Assert::assertContains('Can\'t use any of your 2-Step Verification options', $page->getContent());
     }
 
     /**
@@ -704,11 +704,19 @@ class MfaContext implements Context
     }
 
     /**
-     * @When I click the Send a code link
+     * @When I click the Request Assistance link
      */
-    public function iClickTheSendACodeLink()
+    public function iClickTheRequestAssistanceLink()
     {
-        $this->clickLink('Send a code');
+        $this->clickLink('Click here');
+    }
+
+    /**
+     * @When I click the Request a code link
+     */
+    public function iClickTheRequestACodeLink()
+    {
+        $this->clickLink('Request a code');
     }
 
     /**
@@ -736,5 +744,15 @@ class MfaContext implements Context
     public function iSubmitAnIncorrectManagerCode()
     {
         $this->submitMfaValue(FakeIdBrokerClient::INCORRECT_VALUE);
+    }
+
+    /**
+     * @Given I provide credentials that have a manager code
+     */
+    public function iProvideCredentialsThatHaveAManagerCode()
+    {
+        // See `development/idp-local/config/authsources.php` for options.
+        $this->username = 'has_mgr_code';
+        $this->password = 'a';
     }
 }

--- a/features/mfa.feature
+++ b/features/mfa.feature
@@ -186,6 +186,13 @@ Feature: Prompt for MFA credentials
     When I click the Request Assistance link
     Then I should see a prompt for a manager rescue code
 
+  Scenario: Submit a code sent to my manager at an earlier time
+    Given I provide credentials that have a manager code
+      And I login
+      And I click the Request Assistance link
+    When I submit the correct manager code
+    Then I should end up at my intended destination
+
   Scenario: Submit a correct manager code
     Given I provide credentials that have backup codes
       And the user has a manager email

--- a/features/mfa.feature
+++ b/features/mfa.feature
@@ -183,21 +183,23 @@ Feature: Prompt for MFA credentials
     Given I provide credentials that have backup codes
       And the user has a manager email
       And I login
-    When I click the Send a code link
+    When I click the Request Assistance link
     Then I should see a prompt for a manager rescue code
 
   Scenario: Submit a correct manager code
     Given I provide credentials that have backup codes
       And the user has a manager email
       And I login
-      And I click the Send a code link
+      And I click the Request Assistance link
+      And I click the Request a code link
     When I submit the correct manager code
     Then I should end up at my intended destination
 
-  Scenario: Submit a correct manager code
+  Scenario: Submit an incorrect manager code
     Given I provide credentials that have backup codes
-    And the user has a manager email
-    And I login
-    And I click the Send a code link
+      And the user has a manager email
+      And I login
+      And I click the Request Assistance link
+      And I click the Request a code link
     When I submit an incorrect manager code
     Then I should see a message that it was incorrect

--- a/lib/Auth/Process/Mfa.php
+++ b/lib/Auth/Process/Mfa.php
@@ -769,7 +769,7 @@ class sspmod_mfa_Auth_Process_Mfa extends SimpleSAML_Auth_ProcessingFilter
         $state['mfaOptions'] = $mfaOptions;
         $stateId = SimpleSAML_Auth_State::saveState($state, self::STAGE_SENT_TO_MFA_PROMPT);
 
-        $url = SimpleSAML\Module::getModuleURL('mfa/prompt-for-mfa.php');
+        $url = SimpleSAML\Module::getModuleURL('mfa/mfa-recovery.php');
 
         HTTP::redirectTrustedURL($url, ['mfaId' => $mfaOption['id'], 'StateId' => $stateId]);
     }
@@ -787,5 +787,23 @@ class sspmod_mfa_Auth_Process_Mfa extends SimpleSAML_Auth_ProcessingFilter
             return false;
         }
         return true;
+    }
+
+    /**
+     * Get the manager MFA, if it exists. Otherwise, return null.
+     *
+     * @param array[] $mfaOptions The available MFA options.
+     * @return array The manager MFA.
+     * @throws \InvalidArgumentException
+     */
+    public static function getManagerMfa($mfaOptions)
+    {
+        foreach ($mfaOptions as $mfaOption) {
+            if ($mfaOption['type'] === 'manager') {
+                return $mfaOption;
+            }
+        }
+
+        return null;
     }
 }

--- a/templates/prompt-for-mfa-backupcode.php
+++ b/templates/prompt-for-mfa-backupcode.php
@@ -48,8 +48,8 @@ if (! empty($this->data['errorMessage'])) {
     <?php if ($this->data['hasManagerEmail']): ?>
         <p>
             Can't use any of your 2-Step Verification options?
-            <a href="send-manager-mfa.php?StateId=<?= htmlentities($this->data['stateId']) ?>&mfaId=<?= htmlentities($mfaOpt['id']) ?>">
-                Send a code</a> to your manager.
+            <a href="mfa-recovery.php?StateId=<?= htmlentities($this->data['stateId']) ?>">
+                Click here</a> for assistance.
         </p>
     <?php endif; ?>
 </form>

--- a/templates/prompt-for-mfa-manager.php
+++ b/templates/prompt-for-mfa-manager.php
@@ -15,13 +15,14 @@ if (! empty($this->data['errorMessage'])) {
 <form method="post">
     <h2>Manager Rescue Code</h2>
     <p>
+        We can send a code to your manager. To request a code,
+        <a href="send-manager-mfa.php?StateId=<?= htmlentities($this->data['stateId']) ?>">click here</a>.
+    </p>
+    <p>
       When you receive your code from your manager, enter it here.
     </p>
     <p>
         Enter code: <input type="text" id="mfaSubmission" name="mfaSubmission" />
-        <br />
-        <input type="checkbox" name="rememberMe" id="rememberMe" value="true" checked="checked"/>
-        <label for="rememberMe">Remember this computer for 30 days</label>
         <br />
         <button type="submit" id="submitMfa" name="submitMfa"
                 style="padding: 4px 8px;">Submit</button>
@@ -44,11 +45,6 @@ if (! empty($this->data['errorMessage'])) {
             ?>
         </ul>
     <?php endif; ?>
-    <p>
-        Did not receive the code?
-        <a href="send-manager-mfa.php?StateId=<?= htmlentities($this->data['stateId']) ?>&mfaId=<?= htmlentities($mfaOpt['id']) ?>">
-            Send again</a>
-    </p>
 </form>
 <?php
 $this->includeAtTemplateBase('includes/footer.php');

--- a/templates/prompt-for-mfa-manager.php
+++ b/templates/prompt-for-mfa-manager.php
@@ -15,8 +15,8 @@ if (! empty($this->data['errorMessage'])) {
 <form method="post">
     <h2>Manager Rescue Code</h2>
     <p>
-        We can send a code to your manager. To request a code,
-        <a href="send-manager-mfa.php?StateId=<?= htmlentities($this->data['stateId']) ?>">click here</a>.
+        We can send a code to your manager.
+        <a href="send-manager-mfa.php?StateId=<?= htmlentities($this->data['stateId']) ?>">Request a code</a>.
     </p>
     <p>
       When you receive your code from your manager, enter it here.

--- a/templates/prompt-for-mfa-totp.php
+++ b/templates/prompt-for-mfa-totp.php
@@ -44,8 +44,8 @@ if (! empty($this->data['errorMessage'])) {
     <?php if ($this->data['hasManagerEmail']): ?>
         <p>
             Can't use any of your 2-Step Verification options?
-            <a href="send-manager-mfa.php?StateId=<?= htmlentities($this->data['stateId']) ?>&mfaId=<?= htmlentities($mfaOpt['id']) ?>">
-                Send a code</a> to your manager.
+            <a href="mfa-recovery.php?StateId=<?= htmlentities($this->data['stateId']) ?>">
+                Click here</a> for assistance.
         </p>
     <?php endif; ?>
 </form>

--- a/templates/prompt-for-mfa-u2f.php
+++ b/templates/prompt-for-mfa-u2f.php
@@ -67,8 +67,8 @@ $this->includeAtTemplateBase('includes/header.php');
     <?php if ($this->data['hasManagerEmail']): ?>
         <p>
             Can't use any of your 2-Step Verification options?
-            <a href="send-manager-mfa.php?StateId=<?= htmlentities($this->data['stateId']) ?>&mfaId=<?= htmlentities($mfaOpt['id']) ?>">
-                Send a code</a> to your manager.
+            <a href="mfa-recovery.php?StateId=<?= htmlentities($this->data['stateId']) ?>">
+                Click here</a> for assistance.
         </p>
     <?php endif; ?>
 </form>

--- a/www/mfa-recovery.php
+++ b/www/mfa-recovery.php
@@ -54,6 +54,7 @@ $globalConfig = SimpleSAML_Configuration::getInstance();
 $t = new SimpleSAML_XHTML_Template($globalConfig, 'mfa:prompt-for-mfa-manager.php');
 $t->data['stateId'] = $stateId;
 $t->data['mfaOptions'] = $mfaOptions;
+$t->data['errorMessage'] = $errorMessage ?? null;
 $t->show();
 
 $logger->info(json_encode([

--- a/www/mfa-recovery.php
+++ b/www/mfa-recovery.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This "controller" (per MVC) must be called with the following query string
+ * parameters:
+ * - StateId
+ */
+
+use Sil\SspMfa\LoggerFactory;
+use sspmod_mfa_Auth_Process_Mfa as Mfa;
+
+$stateId = filter_input(INPUT_GET, 'StateId');
+if (empty($stateId)) {
+    throw new SimpleSAML_Error_BadRequest('Missing required StateId query parameter.');
+}
+
+$state = SimpleSAML_Auth_State::loadState($stateId, Mfa::STAGE_SENT_TO_MFA_PROMPT);
+$logger = LoggerFactory::getAccordingToState($state);
+
+$mfaOptions = $state['mfaOptions'] ?? [];
+$mfaOption = Mfa::getManagerMfa($mfaOptions);
+
+// If the user has a manager MFA option and has submitted the code in the form ...
+if ($mfaOption !== null && filter_has_var(INPUT_POST, 'submitMfa')) {
+    $mfaId = $mfaOption['id'];
+    $mfaSubmission = filter_input(INPUT_POST, 'mfaSubmission');
+    if (substr($mfaSubmission, 0, 1) == '{') {
+        $mfaSubmission = json_decode($mfaSubmission, true);
+    }
+
+    $rememberMe = false;
+
+    // NOTE: This will only return if validation fails.
+    $errorMessage = Mfa::validateMfaSubmission(
+        $mfaId,
+        $state['employeeId'],
+        $mfaSubmission,
+        $state,
+        $rememberMe,
+        $logger,
+        $mfaOption['type']
+    );
+
+    $logger->warning(json_encode([
+        'event' => 'MFA validation result: failed',
+        'employeeId' => $state['employeeId'],
+        'mfaType' => $mfaOption['type'],
+        'error' => $errorMessage,
+    ]));
+}
+
+$globalConfig = SimpleSAML_Configuration::getInstance();
+
+$t = new SimpleSAML_XHTML_Template($globalConfig, 'mfa:prompt-for-mfa-manager.php');
+$t->data['stateId'] = $stateId;
+$t->data['mfaOptions'] = $mfaOptions;
+$t->show();
+
+$logger->info(json_encode([
+    'event' => 'Presented user with mfa recovery options',
+    'employeeId' => $state['employeeId'],
+]));

--- a/www/send-manager-mfa.php
+++ b/www/send-manager-mfa.php
@@ -7,7 +7,6 @@
  */
 
 use Sil\SspMfa\LoggerFactory;
-use Sil\SspMfa\LoginBrowser;
 use sspmod_mfa_Auth_Process_Mfa as Mfa;
 
 $stateId = filter_input(INPUT_GET, 'StateId');


### PR DESCRIPTION
Changed wording on mfa prompt page, and moved the request for manager code to the `prompt-for-mfa-manager` page. This provides for a scenario where the manager code was requested during a previous session.