### PR TITLE
Fix mfaVerify bug

### DIFF
--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
   
   mfaidp:
-    image: silintl/ssp-base:latest
+    image: silintl/ssp-base:develop-5.0
     volumes:
       - ./:/mfa
       - ./development/enable-debug.sh:/data/enable-debug.sh
@@ -48,7 +48,7 @@ services:
     command: /data/run-dev.sh
   
   mfasp:
-    image: silintl/ssp-base:latest
+    image: silintl/ssp-base:develop-5.0
     volumes:
       # Utilize custom certs
       - ./development/sp-local/cert:/data/vendor/simplesamlphp/simplesamlphp/cert
@@ -68,7 +68,7 @@ services:
       - THEME_USE=default
   
   mfapwmanager:
-    image: silintl/ssp-base:latest
+    image: silintl/ssp-base:develop-5.0
     volumes:
       # Utilize custom certs
       - ./development/sp-local/cert:/data/vendor/simplesamlphp/simplesamlphp/cert
@@ -78,8 +78,6 @@ services:
 
       # Utilize custom metadata
       - ./development/sp-local/metadata/saml20-idp-remote.php:/data/vendor/simplesamlphp/simplesamlphp/metadata/saml20-idp-remote.php
-    ports:
-      - "8082:80"
     environment:
       - ADMIN_EMAIL=john_doe@there.com
       - ADMIN_PASS=sp1

--- a/development/run-tests.sh
+++ b/development/run-tests.sh
@@ -2,7 +2,7 @@
 
 runny ./setup-logentries.sh
 
-runny composer install --no-interaction --no-scripts
+runny composer install --no-interaction --no-scripts --no-progress
 
 # Give composer time to install any new dependencies of this project
 sleep 200

--- a/lib/Auth/Process/Mfa.php
+++ b/lib/Auth/Process/Mfa.php
@@ -428,17 +428,14 @@ class sspmod_mfa_Auth_Process_Mfa extends SimpleSAML_Auth_ProcessingFilter
                     ]));
                     return 'There have been too many wrong answers recently. '
                         . 'Please wait a minute, then try again.';
-                } elseif ($t->httpStatusCode === 400) {
-                    if ($mfaType === 'backupcode') {
-                        return 'Incorrect 2-step verification code. Printable backup codes can only be used once, please try a different code.';
-                    }
-                    return 'Incorrect 2-step verification code.';
+                } else {
+                    $message .= ' (code ' . $t->httpStatusCode . ')';
+                    return $message;
                 }
             }
             
             $logger->critical($t->getCode() . ': ' . $t->getMessage());
-            return 'Something went wrong while we were trying to do the '
-                 . '2-step verification.';
+            return $message;
         }
 
         // Set remember me cookies if requested

--- a/lib/Auth/Process/Mfa.php
+++ b/lib/Auth/Process/Mfa.php
@@ -2,7 +2,7 @@
 
 use Psr\Log\LoggerInterface;
 use Sil\PhpEnv\Env;
-use Sil\Idp\IdBroker\Client\exceptions\MfaRateLimitException;
+use Sil\Idp\IdBroker\Client\ServiceException;
 use Sil\Idp\IdBroker\Client\IdBrokerClient;
 use Sil\Psr3Adapters\Psr3SamlLogger;
 use Sil\SspMfa\LoggerFactory;


### PR DESCRIPTION
idp-id-broker-php-client 3.0.0 changed the return value of mfaVerify from `bool` to `array`. It's now an array of mfa data on success and an exception with 400 or 429 status code on failure.