### PR TITLE
call id-broker mfaList to refresh mfa options data

### DIFF
--- a/features/fakes/FakeIdBrokerClient.php
+++ b/features/fakes/FakeIdBrokerClient.php
@@ -50,6 +50,8 @@ class FakeIdBrokerClient
         return [
             'id' => $id,
             'type' => 'backupcode',
+            'label' => 'Printable Codes',
+            'created_utc' => '2019-01-02T03:04:05Z',
             'data' => [
                 'count' => 4,
             ],
@@ -99,5 +101,36 @@ class FakeIdBrokerClient
             'This Fake ID Broker class does not support creating %s MFA records.',
             $type
         ));
+    }
+
+    /**
+     * Get a list of MFA configurations for given user
+     * @param string $employee_id
+     * @return array
+     * @throws ServiceException
+     */
+    public function mfaList($employee_id)
+    {
+        return [
+            [
+                'id' => 1,
+                'type' => 'backupcode',
+                'label' => 'Printable Codes',
+                'created_utc' => '2019-04-02T16:02:14Z',
+                'last_used_utc' => '2019-04-01T00:00:00Z',
+                'data' => [
+                    'count' => 10
+                ],
+            ],
+            [
+                'id' => 2,
+                'type' => 'totp',
+                'label' => 'Smartphone App',
+                'created_utc' => '2019-04-02T16:02:14Z',
+                'last_used_utc' => '2019-04-01T00:00:00Z',
+                'data' => [
+                ],
+            ],
+        ];
     }
 }

--- a/lib/Auth/Process/Mfa.php
+++ b/lib/Auth/Process/Mfa.php
@@ -874,7 +874,7 @@ class sspmod_mfa_Auth_Process_Mfa extends SimpleSAML_Auth_ProcessingFilter
     }
 
     /**
-     * @param $state array
+     * @param array $state
      * @param LoggerInterface $logger
      */
     protected static function updateStateWithNewMfaData(&$state, $logger)


### PR DESCRIPTION
After code that modifies the mfa data, call id-broker again to get a fresh copy. This is for the benefit of the profilereview module.